### PR TITLE
Do not include keymaster v3 rc when v4 is used.

### DIFF
--- a/rootdir/Android.mk
+++ b/rootdir/Android.mk
@@ -22,6 +22,7 @@ LOCAL_MODULE_CLASS := ETC
 LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc/init
 include $(BUILD_PREBUILT)
 
+ifneq ($(TARGET_KEYMASTER_V4), true)
 include $(CLEAR_VARS)
 LOCAL_MODULE := android.hardware.keymaster@3.0-service-qti
 LOCAL_SRC_FILES := vendor/etc/init/android.hardware.keymaster@3.0-service-qti.rc
@@ -31,9 +32,7 @@ LOCAL_MODULE_SUFFIX := .rc
 LOCAL_MODULE_CLASS := ETC
 LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc/init
 include $(BUILD_PREBUILT)
-endif
-
-ifeq ($(TARGET_KEYMASTER_V4), true)
+else
 include $(CLEAR_VARS)
 LOCAL_MODULE := android.hardware.keymaster@4.0-service-qti
 LOCAL_SRC_FILES := vendor/etc/init/android.hardware.keymaster@4.0-service-qti.rc
@@ -44,6 +43,8 @@ LOCAL_MODULE_CLASS := ETC
 LOCAL_MODULE_PATH := $(TARGET_OUT_VENDOR)/etc/init
 include $(BUILD_PREBUILT)
 endif
+
+endif # $(TARGET_LEGACY_KEYMASTER) != true
 
 include $(CLEAR_VARS)
 LOCAL_MODULE := init.qcom.devstart.sh


### PR DESCRIPTION
This file must be excluded, otherwise the system will try to start
either. When testing with both services available on the odm partition,
things go haywire. Nevertheless, this if statement should be fixed for
correctness.

Change-Id: If44d1f302007c51a5bbf9de353636ef25bcb6bab