### PR TITLE
hardware: power: Remove superfluous interface version includes.

### DIFF
--- a/hardware/power/Android.mk
+++ b/hardware/power/Android.mk
@@ -48,9 +48,6 @@ LOCAL_SHARED_LIBRARIES := \
     libhardware \
     libhidlbase \
     libhidltransport \
-    android.hardware.power@1.0 \
-    android.hardware.power@1.1 \
-    android.hardware.power@1.2 \
     android.hardware.power@1.3
 
 include $(BUILD_EXECUTABLE)


### PR DESCRIPTION
Versions older than 1.3 are already depended upon by 1.3, which extends
on these and thus requires them anyway.

Tested with `m installclean`, builds fine and all versions still end up on the system partition.