### PR TITLE
hardware: power: Share sysfs_write to other compilation units.

### DIFF
--- a/hardware/power/Hints.cpp
+++ b/hardware/power/Hints.cpp
@@ -73,7 +73,7 @@ RQBalanceHintsHandler::~RQBalanceHintsHandler() {
  * \param s    - String to write
  * \return Returns success (true) or failure (false)
  */
-static bool sysfs_write(const char *path, char *s)
+bool sysfs_write(const char *path, const char *s)
 {
     char buf[80];
     int len;
@@ -376,7 +376,7 @@ retry_send:
 int RQBalanceHintsHandler::manage_powerserver(bool start)
 {
     int ret;
-    struct stat st = {0};
+    struct stat st = {};
     struct passwd *pwd;
     struct passwd *grp;
     uid_t uid;

--- a/hardware/power/Hints.h
+++ b/hardware/power/Hints.h
@@ -27,6 +27,8 @@
 
 struct RQBalanceHALExt;
 
+bool sysfs_write(const char *path, const char *s);
+
 struct RQBalanceHintsHandler {
     RQBalanceHintsHandler();
     ~RQBalanceHintsHandler();


### PR DESCRIPTION
This function is used by Power::setFeature when TAP_TO_WAKE_NODE is
defined.
Also, `const` is *required* by the C++ compiler in order to pass a
string literal.
@kholk Not sure if we want to leave this function here, or move it to a utility file.

Finally, fix the missing-field-initializers warning: C++ uses an empty
bracket list (without it, the first field will be initialized to the
specified value [zero in this case] and the rest to the default of zero,
giving the compiler enough reason to warn about missing explicit values
for the other fields).